### PR TITLE
Add a process to strip the subdomain parts from a hostname

### DIFF
--- a/ZenPacks/Iwillfearnoevil/Domain/libexec/check_certs_Nagios.sh
+++ b/ZenPacks/Iwillfearnoevil/Domain/libexec/check_certs_Nagios.sh
@@ -242,7 +242,7 @@ check_server_status() {
         TLSFLAG=""
     fi
 
-    echo "" | ${OPENSSL} s_client -connect ${1}:${2} ${TLSFLAG} 2> ${ERROR_TMP} 1> ${CERT_TMP}
+    echo "" | ${OPENSSL} s_client -servername ${1} -connect ${1}:${2} ${TLSFLAG} 2> ${ERROR_TMP} 1> ${CERT_TMP}
 
     if ${GREP} -i  "Connection refused" ${ERROR_TMP} > /dev/null
     then


### PR DESCRIPTION
Added a funcion to the script (based on the code from https://github.com/aseques/debian-server-tools/blob/master/monitoring/domain-expiry.sh) that is able the extract the domain part from any complex hostname.
This allows us to create devices that can be any type of subdomains, mostly useful for ssl domains for example:
- database.example.com
- web.example.com
